### PR TITLE
Update stitching upload workflow

### DIFF
--- a/reef_imaging/hypha_tools/artifact_manager/core.py
+++ b/reef_imaging/hypha_tools/artifact_manager/core.py
@@ -14,7 +14,7 @@ load_dotenv()
 class Config:
     """Configuration settings for the artifact manager"""
     SERVER_URL = "https://hypha.aicell.io"
-    WORKSPACE_TOKEN = os.getenv("SQUID_WORKSPACE_TOKEN")
+    WORKSPACE_TOKEN = os.getenv("AGENT_LENS_WORKSPACE_TOKEN")
     CONCURRENCY_LIMIT = 25  # Max number of concurrent uploads (increased from 10)
     MAX_RETRIES = 300  # Maximum number of retry attempts
     MAX_RETRIES_PER_FILE = 10  # Maximum number of retry attempts per file

--- a/reef_imaging/hypha_tools/artifact_manager/core.py
+++ b/reef_imaging/hypha_tools/artifact_manager/core.py
@@ -31,40 +31,12 @@ class Config:
 class UploadRecord:
     """Manages the record of uploaded files"""
     
-    def __init__(self, record_file: str):
-        self.record_file = record_file
+    def __init__(self):
         self.uploaded_files: Set[str] = set()
         self.last_update: Optional[str] = None
         self.total_files: int = 0
         self.completed_files: int = 0
-        self.load()
     
-    def load(self) -> None:
-        """Load the record of previously uploaded files"""
-        if os.path.exists(self.record_file):
-            with open(self.record_file, "r", encoding="utf-8") as f:
-                record = json.load(f)
-                self.uploaded_files = set(record.get("uploaded_files", []))
-                self.last_update = record.get("last_update")
-                self.total_files = record.get("total_files", 0)
-                self.completed_files = record.get("completed_files", 0)
-    
-    def save(self) -> None:
-        """Save the record of uploaded files"""
-        # Convert set to list for JSON serialization
-        record = {
-            "uploaded_files": list(self.uploaded_files),
-            "last_update": datetime.now().isoformat(),
-            "total_files": self.total_files,
-            "completed_files": self.completed_files
-        }
-        
-        with open(self.record_file, "w", encoding="utf-8") as f:
-            json.dump(record, f, indent=2)
-    
-    def is_uploaded(self, relative_path: str) -> bool:
-        """Check if a file has been uploaded"""
-        return relative_path in self.uploaded_files
     
     def mark_uploaded(self, relative_path: str) -> None:
         """Mark a file as uploaded"""

--- a/reef_imaging/hypha_tools/artifact_manager/core.py
+++ b/reef_imaging/hypha_tools/artifact_manager/core.py
@@ -14,7 +14,7 @@ load_dotenv()
 class Config:
     """Configuration settings for the artifact manager"""
     SERVER_URL = "https://hypha.aicell.io"
-    WORKSPACE_TOKEN = os.getenv("AGENT_LENS_WORKSPACE_TOKEN")
+    WORKSPACE_TOKEN = os.getenv("SQUID_WORKSPACE_TOKEN")
     CONCURRENCY_LIMIT = 25  # Max number of concurrent uploads (increased from 10)
     MAX_RETRIES = 300  # Maximum number of retry attempts
     MAX_RETRIES_PER_FILE = 10  # Maximum number of retry attempts per file

--- a/reef_imaging/hypha_tools/artifact_manager/gallery_manager.py
+++ b/reef_imaging/hypha_tools/artifact_manager/gallery_manager.py
@@ -2,7 +2,7 @@ import os
 import asyncio
 from typing import Dict, Any, Optional
 
-from core import HyphaConnection, Config
+from .core import HyphaConnection, Config
 
 class GalleryManager:
     """Manages galleries and datasets in Hypha"""
@@ -107,7 +107,7 @@ async def create_gallery_example() -> None:
         await gallery_manager.create_gallery(
             name="Image Map of U2OS FUCCI Drug Treatment",
             description="A collection for organizing imaging datasets acquired by microscopes",
-            alias="agent-lens/image-map-of-u2os-fucci-drug-treatment-zip",
+            alias="squid-control/image-map-of-u2os-fucci-drug-treatment-zip",
             permissions = {"*": "*", "@": "*", "misty-teeth-42051243": "*","google-oauth2|103047988474094226050": "*"}
         )
     finally:
@@ -121,8 +121,8 @@ async def create_dataset_example() -> None:
         await gallery_manager.create_dataset(
             name="20250429-treatment",
             description="The Image Map of U2OS FUCCI Drug Treatment from 20250429",
-            alias="agent-lens/image-map-20250429-treatment-zip",
-            parent_id="agent-lens/image-map-of-u2os-fucci-drug-treatment-zip",
+            alias="squid-control/image-map-20250429-treatment-zip",
+            parent_id="squid-control/image-map-of-u2os-fucci-drug-treatment-zip",
             version="stage",
             permissions = {"*": "*", "@": "*", "misty-teeth-42051243": "*","google-oauth2|103047988474094226050": "*"}
         )
@@ -132,7 +132,7 @@ async def create_dataset_example() -> None:
 async def commit_dataset_example() -> None:
     """Example of committing a dataset"""
     gallery_manager = GalleryManager()
-    await gallery_manager.commit_dataset(alias="agent-lens/image-map-20250429-treatment-zip")
+    await gallery_manager.commit_dataset(alias="squid-control/image-map-20250429-treatment-zip")
     await gallery_manager.connection.disconnect()
 
 async def delete_dataset_example() -> None:
@@ -143,7 +143,7 @@ async def delete_dataset_example() -> None:
     print("Dataset deleted.")
     await gallery_manager.connection.disconnect()
 
-async def reset_stats(artifact_id="agent-lens/image-map-u2os-fucci-drug-treatment"):
+async def reset_stats(artifact_id="squid-control/image-map-u2os-fucci-drug-treatment"):
     """Reset the stats of a dataset"""
     gallery_manager = GalleryManager()
     await gallery_manager.connection.connect(client_id=None)
@@ -152,4 +152,5 @@ async def reset_stats(artifact_id="agent-lens/image-map-u2os-fucci-drug-treatmen
     await gallery_manager.connection.disconnect()
 if __name__ == "__main__":
 
-    asyncio.run(commit_dataset_example())
+    asyncio.run(create_gallery_example())
+    asyncio.run(create_dataset_example())

--- a/reef_imaging/hypha_tools/artifact_manager/stitch_manager.py
+++ b/reef_imaging/hypha_tools/artifact_manager/stitch_manager.py
@@ -223,7 +223,8 @@ class ZarrWriter:
                 shape=(self.canvas_height, self.canvas_width),
                 chunks=self.chunk_size,
                 dtype=np.uint8,
-                compressor=zarr.Blosc(cname="zstd", clevel=5, shuffle=zarr.Blosc.BITSHUFFLE)
+                compressor=zarr.Blosc(cname="zstd", clevel=5, shuffle=zarr.Blosc.BITSHUFFLE),
+                dimension_separator='/'
             )
 
             # Create pyramid levels
@@ -245,7 +246,8 @@ class ZarrWriter:
                     shape=level_shape,
                     chunks=level_chunks,
                     dtype=np.uint8,
-                    compressor=zarr.Blosc(cname="zstd", clevel=5, shuffle=zarr.Blosc.BITSHUFFLE)
+                    compressor=zarr.Blosc(cname="zstd", clevel=5, shuffle=zarr.Blosc.BITSHUFFLE),
+                    dimension_separator='/'
                 )
 
         self.root = root

--- a/reef_imaging/hypha_tools/artifact_manager/stitch_manager.py
+++ b/reef_imaging/hypha_tools/artifact_manager/stitch_manager.py
@@ -8,6 +8,7 @@ from tqdm import tqdm
 import json
 from typing import Dict, List, Tuple, Optional, Union, Any
 import shutil
+import re
 
 class ImagingParameters:
     """Class for handling imaging parameters"""
@@ -336,6 +337,80 @@ class ImageFileParser:
         return image_info
 
 
+def add_chunk_metadata(zarr_path: str, chunk_metadata: Dict[str, Dict[str, Any]]) -> bool:
+    """
+    Add per-chunk metadata to an existing OME-Zarr dataset.
+    
+    Args:
+        zarr_path: Path to the OME-Zarr dataset
+        chunk_metadata: Dictionary containing metadata for each chunk.
+                       Keys should be string representations of chunk coordinates (e.g., "(0, 0, 0)")
+                       Values should be dictionaries containing metadata fields
+    
+    Returns:
+        bool: True if metadata was added successfully, False otherwise
+    
+    Example:
+        >>> chunk_metadata = {
+        ...     "(0, 0, 0)": {"date": "2025-05-06", "sample": "A1", "location_mm": (10.5, 15.2), "coordinates": (0, 0), "notes": "Sample area 1"},
+        ...     "(0, 1, 0)": {"date": "2025-05-06", "sample": "A2", "location_mm": (10.5, 20.3), "coordinates": (0, 1), "notes": "Sample area 2"}
+        ... }
+        >>> add_chunk_metadata("/path/to/dataset.zarr", chunk_metadata)
+        True
+    """
+    try:
+        # Validate zarr path
+        if not os.path.exists(zarr_path) or not os.path.isdir(zarr_path):
+            print(f"Error: Invalid zarr path: {zarr_path}")
+            return False
+            
+        # Validate metadata format
+        for chunk_coords, metadata in chunk_metadata.items():
+            # Check if chunk coordinates format is valid (e.g., "(0, 0, 0)")
+            if not re.match(r"^\(\d+(?:,\s*\d+)*\)$", chunk_coords):
+                print(f"Error: Invalid chunk coordinate format: {chunk_coords}")
+                return False
+                
+            # Check if metadata is a dictionary
+            if not isinstance(metadata, dict):
+                print(f"Error: Metadata for chunk {chunk_coords} must be a dictionary")
+                return False
+
+        # Path to chunk metadata file
+        metadata_file = os.path.join(zarr_path, "chunk_metadata.json")
+        
+        # Load existing metadata if it exists
+        existing_metadata = {}
+        if os.path.exists(metadata_file):
+            try:
+                with open(metadata_file, 'r') as f:
+                    existing_metadata = json.load(f)
+                print(f"Found existing metadata for {len(existing_metadata)} chunks")
+            except json.JSONDecodeError:
+                print(f"Warning: Could not parse existing metadata file, creating new one")
+            except Exception as e:
+                print(f"Warning: Error reading existing metadata file: {e}")
+        
+        # Update metadata with new values
+        for chunk_coords, metadata in chunk_metadata.items():
+            if chunk_coords in existing_metadata:
+                existing_metadata[chunk_coords].update(metadata)
+            else:
+                existing_metadata[chunk_coords] = metadata
+                
+        # Write updated metadata back to file
+        with open(metadata_file, 'w') as f:
+            json.dump(existing_metadata, f, indent=2)
+            
+        print(f"Successfully added metadata for {len(chunk_metadata)} chunks to {metadata_file}")
+        return True
+        
+    except Exception as e:
+        print(f"Error adding chunk metadata: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+        
 class StitchManager:
     """Manages the image stitching process"""
     
@@ -561,6 +636,53 @@ class StitchManager:
                     self.zarr_writer.update_pyramid(channel, level, image, x_start, y_start)
 
                 del image
+
+    def add_dataset_metadata(self, zarr_path: str, metadata: Dict[str, Any]) -> bool:
+        """
+        Add general metadata to the root of an OME-Zarr dataset.
+        
+        Args:
+            zarr_path: Path to the OME-Zarr dataset
+            metadata: Dictionary containing dataset-level metadata
+            
+        Returns:
+            bool: True if metadata was added successfully, False otherwise
+        """
+        try:
+            # Validate zarr path
+            if not os.path.exists(zarr_path) or not os.path.isdir(zarr_path):
+                print(f"Error: Invalid zarr path: {zarr_path}")
+                return False
+                
+            # Path to dataset metadata file
+            metadata_file = os.path.join(zarr_path, "dataset_metadata.json")
+            
+            # Load existing metadata if it exists
+            existing_metadata = {}
+            if os.path.exists(metadata_file):
+                try:
+                    with open(metadata_file, 'r') as f:
+                        existing_metadata = json.load(f)
+                except json.JSONDecodeError:
+                    print(f"Warning: Could not parse existing metadata file, creating new one")
+                except Exception as e:
+                    print(f"Warning: Error reading existing metadata file: {e}")
+            
+            # Update metadata with new values
+            existing_metadata.update(metadata)
+                    
+            # Write updated metadata back to file
+            with open(metadata_file, 'w') as f:
+                json.dump(existing_metadata, f, indent=2)
+                
+            print(f"Successfully added dataset metadata to {metadata_file}")
+            return True
+            
+        except Exception as e:
+            print(f"Error adding dataset metadata: {e}")
+            import traceback
+            traceback.print_exc()
+            return False
 
 
 def stitch_images_example() -> None:

--- a/reef_imaging/hypha_tools/artifact_manager/test_artifact_manager.py
+++ b/reef_imaging/hypha_tools/artifact_manager/test_artifact_manager.py
@@ -1,0 +1,102 @@
+
+from hypha_rpc import connect_to_server
+from io import BytesIO
+from zipfile import ZipFile
+import httpx
+
+SERVER_URL = "https://hypha.aicell.io"
+
+
+async def test_get_zip_file_content_endpoint(
+    minio_server, fastapi_server, test_user_token
+):
+    """Test retrieving specific content and listing directories from a ZIP file stored in S3."""
+
+    # Connect and get the artifact manager service
+    api = await connect_to_server(
+        {"name": "test-client", "server_url": SERVER_URL, "token": test_user_token}
+    )
+    artifact_manager = await api.get_service("public/artifact-manager")
+
+    # Create a collection and retrieve the UUID
+    collection_manifest = {
+        "name": "test-collection",
+        "description": "A test collection",
+    }
+    collection = await artifact_manager.create(
+        type="collection",
+        manifest=collection_manifest,
+        config={"permissions": {"*": "r", "@": "rw+"}},
+    )
+
+    # Create a dataset within the collection
+    dataset_manifest = {
+        "name": "test-dataset",
+        "description": "A test dataset",
+    }
+    dataset = await artifact_manager.create(
+        type="dataset",
+        parent_id=collection.id,
+        manifest=dataset_manifest,
+        version="stage",
+    )
+
+    # Create a ZIP file in memory
+    zip_buffer = BytesIO()
+    with ZipFile(zip_buffer, "w") as zip_file:
+        zip_file.writestr("example.txt", "file contents of example.txt")
+        zip_file.writestr("nested/example2.txt", "file contents of nested/example2.txt")
+        zip_file.writestr(
+            "nested/subdir/example3.txt", "file contents of nested/subdir/example3.txt"
+        )
+    zip_buffer.seek(0)
+
+    # Upload the ZIP file to the artifact
+    zip_file_path = "test-files"
+    put_url = await artifact_manager.put_file(
+        artifact_id=dataset.id,
+        file_path=f"{zip_file_path}.zip",
+        download_weight=1,
+    )
+    async with httpx.AsyncClient(timeout=30) as client:
+        response = await client.put(put_url, data=zip_buffer.read())
+        assert response.status_code == 200
+
+    # Commit the dataset artifact
+    await artifact_manager.commit(artifact_id=dataset.id)
+
+    # Test retrieving `example.txt` from the ZIP file
+    async with httpx.AsyncClient(timeout=30) as client:
+        response = await client.get(
+            f"{SERVER_URL}/{api.config.workspace}/artifacts/{dataset.alias}/zip-files/{zip_file_path}.zip?path=example.txt"
+        )
+        assert response.status_code == 200
+        assert response.text == "file contents of example.txt"
+
+    # Test retrieving `nested/example2.txt` from the ZIP file
+    async with httpx.AsyncClient(timeout=30) as client:
+        response = await client.get(
+            f"{SERVER_URL}/{api.config.workspace}/artifacts/{dataset.alias}/zip-files/{zip_file_path}.zip?path=nested/example2.txt"
+        )
+        assert response.status_code == 200
+        assert response.text == "file contents of nested/example2.txt"
+
+    # Test retrieving a non-existent file
+    async with httpx.AsyncClient(timeout=30) as client:
+        response = await client.get(
+            f"{SERVER_URL}/{api.config.workspace}/artifacts/{dataset.alias}/zip-files/{zip_file_path}.zip?path=nonexistent.txt"
+        )
+        assert response.status_code == 404
+        assert response.json()["detail"] == "File not found inside ZIP: nonexistent.txt"
+
+    # Test listing a non-existent directory
+    async with httpx.AsyncClient(timeout=30) as client:
+        response = await client.get(
+            f"{SERVER_URL}/{api.config.workspace}/artifacts/{dataset.alias}/zip-files/{zip_file_path}.zip?path=nonexistent/"
+        )
+        assert response.status_code == 200
+        assert (
+            response.json() == []
+        )  # An empty list indicates an empty or non-existent directory.
+
+

--- a/reef_imaging/hypha_tools/artifact_manager/test_artifact_manager.py
+++ b/reef_imaging/hypha_tools/artifact_manager/test_artifact_manager.py
@@ -1,20 +1,24 @@
-
-from hypha_rpc import connect_to_server
+from core import connect_to_server
+import httpx
 from io import BytesIO
 from zipfile import ZipFile
-import httpx
-
+import asyncio
+import os
+import tempfile
+import json
+import numpy as np
 SERVER_URL = "https://hypha.aicell.io"
 
 
+
 async def test_get_zip_file_content_endpoint(
-    minio_server, fastapi_server, test_user_token
+    test_user_token
 ):
     """Test retrieving specific content and listing directories from a ZIP file stored in S3."""
 
     # Connect and get the artifact manager service
     api = await connect_to_server(
-        {"name": "test-client", "server_url": SERVER_URL, "token": test_user_token}
+        {"name": "test-client", "server_url": SERVER_URL, "token": test_user_token, "workspace": "agent-lens"}
     )
     artifact_manager = await api.get_service("public/artifact-manager")
 
@@ -41,16 +45,77 @@ async def test_get_zip_file_content_endpoint(
         version="stage",
     )
 
-    # Create a ZIP file in memory
-    zip_buffer = BytesIO()
-    with ZipFile(zip_buffer, "w") as zip_file:
+    # Create a ZIP file on disk
+    temp_dir = tempfile.gettempdir()
+    zip_file_path_on_disk = os.path.join(temp_dir, "test-files.zip")
+    
+    with ZipFile(zip_file_path_on_disk, "w") as zip_file:
+        # Add regular files
         zip_file.writestr("example.txt", "file contents of example.txt")
         zip_file.writestr("nested/example2.txt", "file contents of nested/example2.txt")
         zip_file.writestr(
             "nested/subdir/example3.txt", "file contents of nested/subdir/example3.txt"
         )
-    zip_buffer.seek(0)
+        
+        # Create and add .zarr chunk files
+        # Create zarr metadata files
+        zarr_attrs = {"_ARRAY_DIMENSIONS": ["z", "y", "x"], "datatype": "float32"}
+        zarr_attrs_json = json.dumps(zarr_attrs)
+        zip_file.writestr("nested-zarr/.zattrs", zarr_attrs_json)
+        
+        # Create 1100 chunks of 1x1 to verify the file size's affect on the artifact manager
+        chunk_shape = [246, 256]
+        array_shape = [11, 10, 10]  # Shape of the entire array
 
+        
+        zarr_array = {
+            "chunks": chunk_shape,
+            "compressor": {"id": "zlib", "level": 1},
+            "dtype": "<f4",
+            "fill_value": "NaN",
+            "filters": None,
+            "order": "C",
+            "shape": [chunk_shape[0] * array_shape[0], chunk_shape[1] * array_shape[1], array_shape[2]],
+            "zarr_format": 2
+        }
+        zarr_array_json = json.dumps(zarr_array)
+        zip_file.writestr("nested-zarr/.zarray", zarr_array_json)
+        
+        # Create some chunk files with random data
+        # We'll create a 3D array (z, y, x) with chunks across all dimensions
+        print("Creating Zarr chunks for approximately 100MB file size...")
+        total_chunks = array_shape[0] * array_shape[1] * array_shape[2]
+        chunk_count = 0
+        
+        # Create a reusable chunk of random data to save memory
+        chunk_data = np.random.rand(chunk_shape[0], chunk_shape[1]).astype(np.float32)
+        chunk_bytes = chunk_data.tobytes()
+        
+        # Add chunks to the zip file
+        for z in range(array_shape[2]):  # 10
+            for y in range(array_shape[1]):  # 20
+                for x in range(array_shape[0]):  # 20
+                    # Add to zip file with zarr chunk naming convention
+                    zip_file.writestr(f"nested-zarr/{x}.{y}.{z}", chunk_bytes)
+                    
+                    # Print progress
+                    chunk_count += 1
+                    if chunk_count % 100 == 0:
+                        progress = (chunk_count / total_chunks) * 100
+                        print(f"Progress: {progress:.1f}% ({chunk_count}/{total_chunks} chunks)")
+        
+        # Add a zarr group
+        zarr_group = {"zarr_format": 2}
+        zarr_group_json = json.dumps(zarr_group)
+        zip_file.writestr("nested-zarr/subgroup/.zgroup", zarr_group_json)
+        
+        # Add a README in the zarr directory
+        zip_file.writestr("nested-zarr/README.md", "This is a zarr directory containing a large 3D array with 256x256 chunks")
+    
+    # Get the size of the ZIP file
+    zip_size_mb = os.path.getsize(zip_file_path_on_disk) / (1024 * 1024)
+    print(f"Created ZIP file: {zip_file_path_on_disk} (Size: {zip_size_mb:.2f} MB)")
+    
     # Upload the ZIP file to the artifact
     zip_file_path = "test-files"
     put_url = await artifact_manager.put_file(
@@ -58,31 +123,34 @@ async def test_get_zip_file_content_endpoint(
         file_path=f"{zip_file_path}.zip",
         download_weight=1,
     )
-    async with httpx.AsyncClient(timeout=30) as client:
-        response = await client.put(put_url, data=zip_buffer.read())
+    print(f"put_url: {put_url}, dataset.id: {dataset.id}")
+    async with httpx.AsyncClient(timeout=300) as client:
+        # Use data parameter with the file contents for async compatibility
+        with open(zip_file_path_on_disk, "rb") as f:
+            file_data = f.read()
+        response = await client.put(put_url, data=file_data)
         assert response.status_code == 200
 
     # Commit the dataset artifact
     await artifact_manager.commit(artifact_id=dataset.id)
-
+    print(f"you can test the dataset at {SERVER_URL}/{api.config.workspace}/artifacts/{dataset.alias}/zip-files/{zip_file_path}.zip")
     # Test retrieving `example.txt` from the ZIP file
-    async with httpx.AsyncClient(timeout=30) as client:
+    async with httpx.AsyncClient(timeout=300) as client:
         response = await client.get(
-            f"{SERVER_URL}/{api.config.workspace}/artifacts/{dataset.alias}/zip-files/{zip_file_path}.zip?path=example.txt"
+            f"{SERVER_URL}/{api.config.workspace}/artifacts/{dataset.alias}/zip-files/{zip_file_path}.zip"
         )
         assert response.status_code == 200
-        assert response.text == "file contents of example.txt"
 
     # Test retrieving `nested/example2.txt` from the ZIP file
-    async with httpx.AsyncClient(timeout=30) as client:
+    async with httpx.AsyncClient(timeout=300) as client:
         response = await client.get(
             f"{SERVER_URL}/{api.config.workspace}/artifacts/{dataset.alias}/zip-files/{zip_file_path}.zip?path=nested/example2.txt"
         )
         assert response.status_code == 200
         assert response.text == "file contents of nested/example2.txt"
-
+    print(f"url: {SERVER_URL}/{api.config.workspace}/artifacts/{dataset.alias}/zip-files/{zip_file_path}.zip?path=example.txt")
     # Test retrieving a non-existent file
-    async with httpx.AsyncClient(timeout=30) as client:
+    async with httpx.AsyncClient(timeout=300) as client:
         response = await client.get(
             f"{SERVER_URL}/{api.config.workspace}/artifacts/{dataset.alias}/zip-files/{zip_file_path}.zip?path=nonexistent.txt"
         )
@@ -90,7 +158,7 @@ async def test_get_zip_file_content_endpoint(
         assert response.json()["detail"] == "File not found inside ZIP: nonexistent.txt"
 
     # Test listing a non-existent directory
-    async with httpx.AsyncClient(timeout=30) as client:
+    async with httpx.AsyncClient(timeout=300) as client:
         response = await client.get(
             f"{SERVER_URL}/{api.config.workspace}/artifacts/{dataset.alias}/zip-files/{zip_file_path}.zip?path=nonexistent/"
         )
@@ -98,5 +166,18 @@ async def test_get_zip_file_content_endpoint(
         assert (
             response.json() == []
         )  # An empty list indicates an empty or non-existent directory.
+        
+    # Test retrieving a zarr metadata file
+    async with httpx.AsyncClient(timeout=300) as client:
+        response = await client.get(
+            f"{SERVER_URL}/{api.config.workspace}/artifacts/{dataset.alias}/zip-files/{zip_file_path}.zip?path=nested-zarr/.zarray"
+        )
+        assert response.status_code == 200
+        assert json.loads(response.text)["zarr_format"] == 2
+
+    # Clean up the temporary ZIP file
+    os.remove(zip_file_path_on_disk)
 
 
+token=os.environ.get("AGENT_LENS_WORKSPACE_TOKEN")
+asyncio.run(test_get_zip_file_content_endpoint(token))

--- a/reef_imaging/hypha_tools/artifact_manager/uploader.py
+++ b/reef_imaging/hypha_tools/artifact_manager/uploader.py
@@ -63,7 +63,13 @@ class ArtifactUploader:
         parts = folder_name.split('_')
         if len(parts) >= 3:
             # Format: 20250410-fucci-time-lapse-scan_2025-04-10_13-50-7.762411
-            return parts[1] + '_' + parts[2].split('.')[0]  # Returns: 2025-04-10_13-50-7
+            time_part = parts[2].split('.')[0]  # Get time part without microseconds
+            time_components = time_part.split('-')
+            if len(time_components) == 3:
+                # Pad single-digit seconds with leading zero
+                time_components[2] = time_components[2].zfill(2)
+                time_part = '-'.join(time_components)
+            return parts[1] + '_' + time_part  # Returns: 2025-04-10_13-50-02
         return folder_name  # Fallback to full folder name if format doesn't match
     
     async def upload_single_file(self, local_file: str, relative_path: str) -> bool:

--- a/reef_imaging/hypha_tools/artifact_manager/uploader.py
+++ b/reef_imaging/hypha_tools/artifact_manager/uploader.py
@@ -169,7 +169,7 @@ class ArtifactUploader:
         def create_zip_file(source_path, target_zip_path):
             print(f"Creating zip file for {source_path} in background thread...")
             try:
-                with zipfile.ZipFile(target_zip_path, 'w', zipfile.ZIP_DEFLATED) as zipf:
+                with zipfile.ZipFile(target_zip_path, 'w', 0) as zipf:
                     for root, _, files in os.walk(source_path):
                         for file in files:
                             file_path = os.path.join(root, file)

--- a/reef_imaging/hypha_tools/artifact_manager/uploader.py
+++ b/reef_imaging/hypha_tools/artifact_manager/uploader.py
@@ -182,56 +182,51 @@ class ArtifactUploader:
                 print(f"Error creating zip file in background thread: {e}")
                 traceback.print_exc()
                 return False
-                
-        # Create a separate upload task
-        async def zip_and_upload_task():
-            try:
-                try:
-                    print(f"Starting zip file creation in background thread for {folder_path}...")
-                    # Run zip creation in a separate thread
-                    zip_success = await asyncio.to_thread(create_zip_file, folder_path, temp_zip_path)
-                    
-                    if not zip_success:
-                        print(f"Failed to create zip file for {folder_path}")
-                        return False
-                    
-                    if not os.path.exists(temp_zip_path):
-                        print(f"Expected zip file {temp_zip_path} doesn't exist after thread completion")
-                        return False
-                    
-                    # Make sure we're connected
-                    connected = await self.ensure_connected()
-                    if not connected:
-                        print(f"Failed to connect, retrying...")
-                        await asyncio.sleep(5)
-                        connected = await self.ensure_connected()
-                        if not connected:
-                            print(f"Failed to establish connection after retry")
-                            return False
-                    
-                    # Upload the zip file
-                    print(f"Zip creation complete, now uploading {temp_zip_path} to {relative_path}...")
-                    success = await self.upload_single_file(temp_zip_path, relative_path)
-                    
-                    return success
-                finally:
-                    # Always clean up the keepalive task
-                    
-                    # Clean up the temporary zip file if requested and if it exists
-                    if delete_zip_after and os.path.exists(temp_zip_path):
-                        try:
-                            os.unlink(temp_zip_path)
-                            print(f"Deleted temporary zip file: {temp_zip_path}")
-                        except Exception as e:
-                            print(f"Warning: Could not delete temporary file {temp_zip_path}: {e}")
-                    
-            except Exception as e:
-                print(f"Error during zip and upload process: {e}")
-                traceback.print_exc()
-                return False
         
-        # Execute the task and wait for it to complete
-        return await zip_and_upload_task()
+        try:
+            # First ensure we have a connection before starting the zip process
+            connected = await self.ensure_connected()
+            if not connected:
+                print(f"Failed to establish initial connection")
+                return False
+
+            # Start the zip process in a separate thread
+            print(f"Starting zip file creation in background thread for {folder_path}...")
+            zip_success = await asyncio.to_thread(create_zip_file, folder_path, temp_zip_path)
+            
+            if not zip_success:
+                print(f"Failed to create zip file for {folder_path}")
+                return False
+            
+            if not os.path.exists(temp_zip_path):
+                print(f"Expected zip file {temp_zip_path} doesn't exist after thread completion")
+                return False
+            
+            # Ensure connection is still alive after zipping
+            connected = await self.ensure_connected()
+            if not connected:
+                print(f"Failed to maintain connection after zipping")
+                return False
+            
+            # Upload the zip file
+            print(f"Zip creation complete, now uploading {temp_zip_path} to {relative_path}...")
+            success = await self.upload_single_file(temp_zip_path, relative_path)
+            
+            return success
+            
+        except Exception as e:
+            print(f"Error during zip and upload process: {e}")
+            traceback.print_exc()
+            return False
+            
+        finally:
+            # Clean up the temporary zip file if requested and if it exists
+            if delete_zip_after and os.path.exists(temp_zip_path):
+                try:
+                    os.unlink(temp_zip_path)
+                    print(f"Deleted temporary zip file: {temp_zip_path}")
+                except Exception as e:
+                    print(f"Warning: Could not delete temporary file {temp_zip_path}: {e}")
 
     async def upload_zarr_files(self, file_paths: List[str]) -> bool:
         """Upload zarr files to the artifact manager - simplified."""

--- a/reef_imaging/hypha_tools/automated_stitch_uploader.py
+++ b/reef_imaging/hypha_tools/automated_stitch_uploader.py
@@ -599,6 +599,10 @@ async def process_folder(folder_name: str) -> bool:
     # step 6, delete UPLOAD_RECORD_FILE
     if os.path.exists(UPLOAD_RECORD_FILE):
         os.remove(UPLOAD_RECORD_FILE)
+    
+    # step 7, delete the .done file
+    if os.path.exists(done_file_path):
+        os.remove(done_file_path)
     return True
 
 

--- a/reef_imaging/hypha_tools/automated_stitch_uploader.py
+++ b/reef_imaging/hypha_tools/automated_stitch_uploader.py
@@ -25,7 +25,8 @@ from artifact_manager.gallery_manager import GalleryManager
 # Constants
 BASE_DIR = "/media/reef/harddisk"
 EXPERIMENT_ID = "20250429-scan-time-lapse"
-STITCHED_DIR = "/media/reef/harddisk/test_stitch_zarr"
+# Replace hardcoded STITCHED_DIR with temp directory
+STITCHED_DIR = tempfile.mkdtemp(prefix="stitch_zarr_")
 STITCH_RECORD_FILE = "stitch_upload_progress.txt"
 UPLOAD_RECORD_FILE = "zarr_upload_record.json"
 CHECK_INTERVAL = 15  # Check for new files every 15 seconds
@@ -799,4 +800,9 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main()) 
+    try:
+        asyncio.run(main())
+    finally:
+        # Clean up temporary directory
+        if os.path.exists(STITCHED_DIR):
+            shutil.rmtree(STITCHED_DIR) 

--- a/reef_imaging/hypha_tools/automated_stitch_uploader.py
+++ b/reef_imaging/hypha_tools/automated_stitch_uploader.py
@@ -901,13 +901,6 @@ async def main():
             while current_idx < len(all_folders):
                 folder_to_process = all_folders[current_idx]
                 
-                # Check if we've reached the end folder
-                if end_folder and folder_to_process == end_folder:
-                    print(f"\nReached end folder: {end_folder}")
-                    if input("\nDo you want to continue monitoring for new folders? (y/n): ").lower() != 'y':
-                        return
-                    break
-                
                 # Skip if already processed
                 if folder_to_process in processed_folders:
                     print(f"Folder {folder_to_process} already processed, skipping.")
@@ -927,6 +920,13 @@ async def main():
                     # If failed, retry after a delay
                     print(f"Failed to process {folder_to_process}. Retrying in {CHECK_INTERVAL} seconds...")
                     await asyncio.sleep(CHECK_INTERVAL)
+                
+                # Check if we've reached the end folder AFTER processing it
+                if end_folder and folder_to_process == end_folder:
+                    print(f"\nReached end folder: {end_folder}")
+                    if input("\nDo you want to continue monitoring for new folders? (y/n): ").lower() != 'y':
+                        return
+                    break
             
             # If no end folder was specified, continue monitoring
             if not end_folder:

--- a/reef_imaging/hypha_tools/automated_stitch_uploader.py
+++ b/reef_imaging/hypha_tools/automated_stitch_uploader.py
@@ -31,7 +31,7 @@ CHECK_INTERVAL = 60  # Check for new folders every 60 seconds
 client_id = "reef-client-stitch-uploader"
 # Load environment variables
 load_dotenv()
-ARTIFACT_ALIAS = "agent-lens/image-map-20250429-treatment-zip"
+ARTIFACT_ALIAS = "squid-control/image-map-20250429-treatment-zip"
 # Timeout and retry settings
 CONNECTION_TIMEOUT = 60  # Timeout for connection operations in seconds
 OPERATION_TIMEOUT = 3600  # Timeout for Hypha operations in seconds (increased from 60)

--- a/reef_imaging/hypha_tools/automated_stitch_uploader.py
+++ b/reef_imaging/hypha_tools/automated_stitch_uploader.py
@@ -123,11 +123,17 @@ def cleanup_zarr_file(zarr_file: str):
 
 def extract_datetime_from_folder(folder_name: str) -> Optional[str]:
     """Extract the datetime string from a folder name."""
-    # Look for timestamp in format YYYY-MM-DD_HH-MM-SS
-    pattern = r"(\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})"
-    match = re.search(pattern, folder_name)
-    if match:
-        return match.group(1)
+    parts = folder_name.split('_')
+    if len(parts) >= 3:
+        # Format: 20250429-scan-time-lapse_2025-04-29_17-53-2.861421
+        date_part = parts[1]  # Extract date part: 2025-04-29
+        time_part = parts[2].split('.')[0]  # Extract time part without microseconds: 17-53-2
+        time_components = time_part.split('-')
+        if len(time_components) == 3:
+            # Pad single-digit seconds with leading zero
+            time_components[2] = time_components[2].zfill(2)
+            time_part = '-'.join(time_components)
+        return date_part + '_' + time_part
     return None
 
 
@@ -201,7 +207,7 @@ async def create_dataset_for_folder(folder_name: str) -> Optional[str]:
     """Create a dataset for a specific folder timestamp."""
     global gallery_manager
     
-    folder_datetime = extract_datetime_from_folder(folder_name)
+    folder_datetime = uploader.extract_datetime_from_folder(folder_name)
     if not folder_datetime:
         print(f"Could not extract datetime from folder name: {folder_name}")
         return None

--- a/reef_imaging/hypha_tools/verify_hypha_zips.py
+++ b/reef_imaging/hypha_tools/verify_hypha_zips.py
@@ -1,0 +1,176 @@
+import os
+import asyncio
+import json
+import datetime
+import aiohttp
+import traceback
+import argparse
+
+# Assuming artifact_manager is in the same directory or PYTHONPATH is set up
+from artifact_manager.core import HyphaConnection, Config
+
+VERIFICATION_LOG_FILE_TEMPLATE = "verification_errors_{}.log"
+
+async def _find_zip_files_recursive(artifact_manager, dataset_alias_full: str, current_dir_path: str = "") -> list[str]:
+    """
+    Recursively finds all .zip files within a dataset artifact.
+    Returns a list of their full paths relative to the artifact root.
+    """
+    zip_file_paths = []
+    normalized_dir_path = current_dir_path.lstrip(os.sep) if current_dir_path else ""
+
+    try:
+        items = await artifact_manager.list_files(
+            artifact_id=dataset_alias_full,
+            dir_path=normalized_dir_path if normalized_dir_path else None
+        )
+        
+        for item in items:
+            item_relative_path = os.path.join(normalized_dir_path, item['name'])
+            
+            if item['type'] == 'file' and item['name'].endswith('.zip'):
+                zip_file_paths.append(item_relative_path)
+            elif item['type'] == 'directory':
+                zip_file_paths.extend(
+                    await _find_zip_files_recursive(artifact_manager, dataset_alias_full, item_relative_path)
+                )
+    except Exception as e:
+        print(f"Error listing files in {dataset_alias_full} at path '{normalized_dir_path}': {e}")
+        log_file_name = VERIFICATION_LOG_FILE_TEMPLATE.format(dataset_alias_full.split('/',1)[-1].replace('/','_'))
+        with open(log_file_name, "a") as f_log:
+            f_log.write(f"Timestamp: {datetime.datetime.now().isoformat()}\n")
+            f_log.write(f"Dataset: {dataset_alias_full}\n")
+            f_log.write(f"Error during _find_zip_files_recursive at path '{normalized_dir_path}': {e}\n{traceback.format_exc()}\n\n")
+    return zip_file_paths
+
+async def verify_dataset_zips(artifact_manager, workspace_name: str, dataset_name_in_url: str, dataset_alias_full: str):
+    """Verifies accessibility of .zip file contents in a committed dataset."""
+    print(f"\nStarting verification for dataset: {dataset_alias_full}")
+
+    log_file_name = VERIFICATION_LOG_FILE_TEMPLATE.format(dataset_name_in_url.replace('/', '_'))
+    
+    try:
+        print(f"  Searching for .zip files in dataset {dataset_alias_full}...")
+        zip_files_in_artifact = await _find_zip_files_recursive(artifact_manager, dataset_alias_full)
+        
+        if not zip_files_in_artifact:
+            print(f"  No .zip files found in dataset {dataset_alias_full} to verify.")
+            return
+
+        print(f"  Found {len(zip_files_in_artifact)} .zip files. Verifying access to their contents...")
+
+        async with aiohttp.ClientSession() as session:
+            for zip_path_in_artifact in zip_files_in_artifact:
+                url_zip_path = zip_path_in_artifact.replace(os.sep, '/') 
+                # Construct the URL for listing zip contents (default is root of zip)
+                zip_content_list_url = f"{Config.SERVER_URL}/{workspace_name}/artifacts/{dataset_name_in_url}/zip-files/{url_zip_path}"
+                
+                error_occurred = False
+                error_message = ""
+
+                try:
+                    print(f"    Verifying: {zip_content_list_url}")
+                    async with session.get(zip_content_list_url, timeout=Config.CONNECTION_TIMEOUT) as response:
+                        if response.status == 200:
+                            try:
+                                content_list = await response.json()
+                                if isinstance(content_list, list):
+                                    print(f"      OK: Listed {len(content_list)} items in {url_zip_path}")
+                                else:
+                                    error_occurred = True
+                                    error_message = f"Error: Response content for {url_zip_path} is not a list. Type: {type(content_list)}"
+                            except aiohttp.ContentTypeError:
+                                error_occurred = True
+                                response_text = await response.text()
+                                error_message = f"Error: Response for {url_zip_path} is not valid JSON. Status: {response.status}. Response text: {response_text[:200]}"
+                            except json.JSONDecodeError:
+                                error_occurred = True
+                                response_text = await response.text()
+                                error_message = f"Error: Failed to decode JSON for {url_zip_path}. Status: {response.status}. Response text: {response_text[:200]}"
+                        else:
+                            error_occurred = True
+                            error_message = f"Error: HTTP status {response.status} for {url_zip_path}."
+                            try:
+                                response_text = await response.text()
+                                error_message += f" Response text: {response_text[:200]}"
+                            except Exception:
+                                error_message += " Could not retrieve response text."
+                except asyncio.TimeoutError:
+                    error_occurred = True
+                    error_message = f"Error: Request timed out for {url_zip_path}."
+                except aiohttp.ClientError as e:
+                    error_occurred = True
+                    error_message = f"Error: Client error for {url_zip_path}: {e}"
+                except Exception as e:
+                    error_occurred = True
+                    error_message = f"Error: An unexpected error occurred for {url_zip_path}: {e}\n{traceback.format_exc()}"
+                
+                if error_occurred:
+                    print(f"      FAIL: {error_message}")
+                    with open(log_file_name, "a") as f_log:
+                        f_log.write(f"Timestamp: {datetime.datetime.now().isoformat()}\n")
+                        f_log.write(f"Dataset: {dataset_alias_full}\n")
+                        f_log.write(f"Zip URL: {zip_content_list_url}\n")
+                        f_log.write(f"Error: {error_message}\n\n")
+        
+        log_exists = os.path.exists(log_file_name)
+        num_errors = 0
+        if log_exists:
+            with open(log_file_name, "r") as f_log:
+                num_errors = f_log.read().count("Error:") 
+
+        if num_errors > 0:
+            print(f"Verification finished for dataset {dataset_alias_full}. {num_errors} error(s) logged to {log_file_name}")
+        elif zip_files_in_artifact:
+            print(f"Verification finished for dataset {dataset_alias_full}. All {len(zip_files_in_artifact)} zip files verified successfully.")
+            if log_exists:
+                try: os.remove(log_file_name)
+                except: pass
+
+    except Exception as e:
+        print(f"  An error occurred during the verification setup for {dataset_alias_full}: {e}")
+        with open(log_file_name, "a") as f_log:
+            f_log.write(f"Timestamp: {datetime.datetime.now().isoformat()}\n")
+            f_log.write(f"Dataset: {dataset_alias_full}\n")
+            f_log.write(f"General Error during verification: {e}\n{traceback.format_exc()}\n\n")
+
+async def main():
+    parser = argparse.ArgumentParser(description="Verify Zarr dataset zip file contents in Hypha.")
+    # parser.add_argument("gallery_alias", type=str, help="The alias of the gallery (e.g., 'workspace_name/gallery_name') - currently unused by verify_dataset_zips but kept for context.")
+    parser.add_argument("dataset_alias_full", type=str, help="The full alias of the dataset (e.g., 'workspace_name/dataset_name').")
+    parser.add_argument("--client_id", type=str, default="reef-client-zip-verifier", help="Client ID for Hypha connection.")
+    
+    args = parser.parse_args()
+
+    hypha_conn = HyphaConnection(server_url=Config.SERVER_URL, token=Config.WORKSPACE_TOKEN)
+    
+    try:
+        await hypha_conn.connect(client_id=args.client_id)
+        if not hypha_conn.artifact_manager:
+            print("Failed to connect to Hypha or get artifact manager. Exiting.")
+            return
+
+        alias_parts = args.dataset_alias_full.split('/', 1)
+        if len(alias_parts) < 2:
+            print(f"Error: Could not parse workspace from dataset alias: {args.dataset_alias_full}")
+            return
+        workspace_name = alias_parts[0]
+        dataset_name_for_url = alias_parts[1] # This is dataset_name or dataset_name/subpath if it's nested
+
+        await verify_dataset_zips(
+            artifact_manager=hypha_conn.artifact_manager,
+            workspace_name=workspace_name,
+            dataset_name_in_url=dataset_name_for_url,
+            dataset_alias_full=args.dataset_alias_full
+        )
+
+    except Exception as e:
+        print(f"An error occurred in main: {e}")
+        traceback.print_exc()
+    finally:
+        if hypha_conn.api:
+            await hypha_conn.disconnect()
+        print("Verification script finished.")
+
+if __name__ == "__main__":
+    asyncio.run(main()) 

--- a/reef_imaging/orchestrator.py
+++ b/reef_imaging/orchestrator.py
@@ -52,7 +52,7 @@ ILLUMINATE_CHANNELS = ['BF LED matrix full', 'Fluorescence 488 nm Ex', 'Fluoresc
 SCANNING_ZONE = [(1, 1), (6, 10)] # The outside rows and columns have no cells
 Nx = 2
 Ny = 2
-ACTION_ID = '20250429-scan-time-lapse'
+ACTION_ID = '20250506-scan-time-lapse'
 
 class OrchestrationSystem:
     def __init__(self, local=False):


### PR DESCRIPTION
This pull request introduces several significant changes across multiple files in the `reef_imaging/hypha_tools/artifact_manager` module. The updates include refactoring the `UploadRecord` class, modifying dataset and gallery aliases, enhancing Zarr file handling, and adding new utility functions and tests. Below is a categorized summary of the most important changes:

### Refactoring and Simplification
* Removed the `record_file` parameter and associated methods (`load`, `save`, `is_uploaded`) from the `UploadRecord` class, simplifying its functionality to focus on tracking uploaded files in memory. (`reef_imaging/hypha_tools/artifact_manager/core.py`)
* Updated the `ArtifactUploader` class to eliminate dependency on `UploadRecord`'s file-based functionality, removing redundant checks for previously uploaded files. (`reef_imaging/hypha_tools/artifact_manager/uploader.py`) [[1]](diffhunk://#diff-08953878d563d5effdfe9cf3c98de069268b811ba17a48cbcadaa64911efbc88L21-L26) [[2]](diffhunk://#diff-08953878d563d5effdfe9cf3c98de069268b811ba17a48cbcadaa64911efbc88L66-R75)

### Alias Updates for Dataset and Gallery Management
* Replaced all occurrences of the `agent-lens` prefix in dataset and gallery aliases with `squid-control` to reflect updated naming conventions. (`reef_imaging/hypha_tools/artifact_manager/gallery_manager.py`) [[1]](diffhunk://#diff-e60cd29440249e56b429bb49b1e308acbeaba1bd8fac4e7258b30445a39ef970L110-R110) [[2]](diffhunk://#diff-e60cd29440249e56b429bb49b1e308acbeaba1bd8fac4e7258b30445a39ef970L124-R125) [[3]](diffhunk://#diff-e60cd29440249e56b429bb49b1e308acbeaba1bd8fac4e7258b30445a39ef970L135-R135) [[4]](diffhunk://#diff-e60cd29440249e56b429bb49b1e308acbeaba1bd8fac4e7258b30445a39ef970L146-R146) [[5]](diffhunk://#diff-e60cd29440249e56b429bb49b1e308acbeaba1bd8fac4e7258b30445a39ef970L155-R156)

### Enhancements to Zarr File Handling
* Added the `dimension_separator='/'` parameter to Zarr file creation, improving compatibility with hierarchical storage structures. (`reef_imaging/hypha_tools/artifact_manager/stitch_manager.py`) [[1]](diffhunk://#diff-3163ec89915c9d93a2d86e5308c878bb904225bf0a4f3018c04499657d19907fL225-R227) [[2]](diffhunk://#diff-3163ec89915c9d93a2d86e5308c878bb904225bf0a4f3018c04499657d19907fL247-R250)
* Introduced two new utility functions: `add_chunk_metadata` for adding per-chunk metadata to OME-Zarr datasets, and `add_dataset_metadata` for adding general metadata at the dataset level. (`reef_imaging/hypha_tools/artifact_manager/stitch_manager.py`) [[1]](diffhunk://#diff-3163ec89915c9d93a2d86e5308c878bb904225bf0a4f3018c04499657d19907fR342-R415) [[2]](diffhunk://#diff-3163ec89915c9d93a2d86e5308c878bb904225bf0a4f3018c04499657d19907fR642-R688)

### Testing Enhancements
* Added a comprehensive test function, `test_get_zip_file_content_endpoint`, to validate ZIP file handling in the artifact manager, including creating, uploading, and retrieving files and metadata. (`reef_imaging/hypha_tools/artifact_manager/test_artifact_manager.py`)

### Miscellaneous Changes
* Fixed a relative import in `gallery_manager.py` to use the correct module path. (`reef_imaging/hypha_tools/artifact_manager/gallery_manager.py`)
* Added `re` module import in `stitch_manager.py` to support regex-based validation in new metadata functions. (`reef_imaging/hypha_tools/artifact_manager/stitch_manager.py`)